### PR TITLE
Created a grammar for configuration

### DIFF
--- a/github_watcher/commands/check.py
+++ b/github_watcher/commands/check.py
@@ -1,6 +1,8 @@
 from github_watcher.commands.run import find_changes
-from github_watcher.commands.config import get_config
+from github_watcher.commands.config import Configuration
 
 
 def main(parser):
-    find_changes(get_config(parser))
+    conf = Configuration.from_file()
+    conf.add_cli_options(parser.parse_args())
+    find_changes(conf)

--- a/github_watcher/commands/config.py
+++ b/github_watcher/commands/config.py
@@ -9,31 +9,18 @@ example configuration is
 
     ---
     akellehe:
-        github_watcher:
-            paths:
-                docs/: <null>,
-                github_watcher/settings.py:
-                    - [0, 1]
-                    - [4, 5]
-            base_url: 'https://api.gitub.com'
-            token: '*****'
-            regexes:
-                - foo
-                - bar
-
-{'akellehe': {
-    'github_watcher': {
-        'paths': {
-            'docs/': '<null>,',
-            'github_watcher/settings.py': [[0, 1], [4, 5]]
-        },
-        'base_url': 'https://api.gitub.com',
-        'token': '*****',
-        'regexes': ['foo', 'bar']
-        }
-    }
-}
-
+        base_url: 'https://api.gitub.com'
+        token: '*****'
+        repos:
+            github_watcher:
+                paths:
+                    docs/: <null>,
+                    github_watcher/settings.py:
+                        - [0, 1]
+                        - [4, 5]
+                regexes:
+                    - foo
+                    - bar
 
 If the configuration above doesn't answer your questions, more explanation is below.
 
@@ -60,9 +47,7 @@ The parameters in a repository are
 
 """
 
-from typing import List, Dict
-import collections
-import logging
+from typing import List
 
 import yaml
 
@@ -71,9 +56,12 @@ import github_watcher.settings as settings
 
 class Range:
 
-    def __init__(self, start: float=float('-inf'), stop: float=float('inf')):
+    def __init__(self, start: float=float('-inf'), end: float=float('inf')):
         self.start = start
-        self.stop = stop
+        self.end = end
+
+    def to_json(self):
+        return [self.start, self.end]
 
 
 class Path:
@@ -82,126 +70,152 @@ class Path:
         self.path = path
         self.ranges = ranges
 
+    def to_json(self):
+        return {
+            self.path: [r.to_json() for r in self.ranges]
+        }
+
 
 class Repo:
 
-    def __init__(self, name: str, paths: List[Path], regexes: List[str],
-                 token: str, base_url: str):
+    def __init__(self, name: str, paths: List[Path]=None, regexes: List[str]=None):
         self.name = name
         self.paths = paths
         self.regexes = regexes
-        self.token = token
-        self.base_url = base_url
+        if paths is None:
+            self.paths = []
+        if regexes is None:
+            self.regexes = []
+
+    def to_json(self):
+        paths = {}
+        for p in self.paths:
+            paths.update(p.to_json())
+        return {
+            self.name: {
+                'paths': paths,
+                'regexes': [r for r in self.regexes] if self.regexes else [],
+            }
+        }
 
     @classmethod
-    def from_yml(cls, name, yml):
+    def from_json(cls, name, yml):
         paths = [
             Path(path=path,
-                 ranges=[Range(start=r[0], stop=r[1])
+                 ranges=[Range(start=r[0], end=r[1])
                          for r in ranges if r] if ranges else [])
             for path, ranges in yml.get('paths', {}).items()]
 
         return Repo(
             name=name,
             paths=paths,
-            base_url=yml.get('base_url', 'https://api.github.com'),
-            token=yml.get('token'),
             regexes=yml.get('regexes')
         )
 
 
 class User:
 
-    def __init__(self, name: str, repos: List[Repo]):
+    def __init__(self, name: str, repos: List[Repo], token: str, base_url: str):
         self.name = name
         self.repos = repos
+        self.token = token
+        self.base_url = base_url
+
+    def to_json(self):
+        repos = {}
+        for r in self.repos:
+            repos.update(r.to_json())
+        return {
+            self.name: {
+                'repos': repos,
+                'token': self.token,
+                'base_url': self.base_url
+            }
+        }
 
     @classmethod
-    def from_yml(cls, name, yml):
+    def from_json(cls, name, yml):
         return User(
             name=name,
-            repos=[Repo.from_yml(name, repo) for name, repo in yml.items()]
+            repos=[Repo.from_json(name, repo) for name, repo in yml.get('repos').items()],
+            base_url=yml.get('base_url', 'https://api.github.com'),
+            token=yml.get('token')
         )
 
 
 class Configuration:
 
-    def __init__(self, users: List[User]):
+    def __init__(self, users: List[User], silent: bool=False, verbose: bool=False):
         self.users = users
+        self.silent = silent
+        self.verbose = verbose
+
+    def to_json(self):
+        users = {}
+        for user in self.users:
+            users.update(user.to_json())
+        return users
+
+    def append_ranges(self, source: List[Range], destination: List[Range]):
+        for source_range in source:
+            destination.append(source_range)
+
+    def append_source_path_to_destination(self, source_path: Path, destination: List[Path]):
+        for dest_path in destination:
+            if source_path.path == dest_path.path:
+                self.append_ranges(source_path.ranges, dest_path.ranges)
+                return
+        destination.append(source_path)
+
+    def append_paths(self, source: List[Path], destination: List[Path]):
+        for source_path in source:
+            self.append_source_path_to_destination(source_path, destination)
+
+    def append_repo(self, source: Repo, destination: List[Repo]):
+        for dest in destination:
+            if dest.name == source.name:
+                self.append_paths(source.paths, dest.paths)
+                return
+        destination.append(source)
+
+    def append_user(self, user):
+        for u in self.users:
+            if u.name == user.name:
+                self.append_repo(user.repo, u.repos)
+
+        self.users.append(user)
+
+
+    def serialize(self):
+        return yaml.dump(self.to_json(), default_flow_style=False)
 
     @classmethod
-    def from_yml(self, yml):
+    def from_json(cls, yml):
+        if not yml:
+            raise RuntimeError("No configuration found.")
         return Configuration(
-            users=[User.from_yml(name, user_conf) for name, user_conf in yml.items()]
+            users=[User.from_json(name, user_conf) for name, user_conf in yml.items()],
+            silent=yml.get('silent', False),
+            verbose=yml.get('verbose', False)
         )
 
+    @classmethod
+    def from_file(cls, filepath: str=None):
+        if filepath is None:
+            filepath = settings.WATCHER_CONFIG
+        try:
+            with open(filepath, 'rb') as config:
+                return Configuration.from_json(yaml.load(config.read().decode('utf-8')))
+        except IOError as e:
+            raise RuntimeError("Config file not found <{}>".format(filepath))
 
-def nonempty_watch_path(args):
-    if all([args.user, args.repo, args.filepath]):
-        return True
-    elif any([args.user, args.repo, args.filepath]):
-        raise RuntimeError("If you pass any of --user, --repo, and --filepath you must pass all of them.")
-    return False
-
-
-def get_cli_config(parser):
-    args = parser.parse_args()
-    cli_config = {}
-    if nonempty_watch_path(args):
-        cli_config = {
-            args.user: {
-                args.repo: {
-                    args.filepath: []}}}
-        if args.start is not None and args.end is not None:
-            cli_config[args.user][args.repo][args.filepath].append(
-                [args.start, args.end])
-    if args.github_url:
-        cli_config['github_api_base_url'] = args.github_url
-    if args.regex:
-        cli_config['watched_regexes'] = [args.regex]
-    if args.silent:
-        cli_config['silent'] = True
-    return cli_config
-
-
-def get_file_config():
-    try:
-        with open(settings.WATCHER_CONFIG, 'rb') as config:
-            return yaml.load(config.read().decode('utf-8'))
-    except IOError as e:
-        logging.warning("{} configuration file not found.".format(settings.WATCHER_CONFIG))
-        return {}
-
-
-def get_config(parser):
-    conf = {}
-    cli_config = get_cli_config(parser)
-    file_config = get_file_config()
-    if not cli_config and not file_config:
-        raise RuntimeError("No configuration found.")
-
-    conf['github_api_secret_token'] = file_config.get('github_api_secret_token')
-    conf['github_api_base_url'] = file_config.get('github_api_base_url')
-
-    if cli_config:
-        conf.update(cli_config)
-        return conf
-
-    conf.update(file_config)
-    conf.update(cli_config)  # CLI args override file settings
-
-    return conf
-
-
-def update(d, u):
-    for k, v in list(u.items()):
-        if isinstance(v, collections.Mapping):
-            d[k] = update(d.get(k, {}), v)
-        elif isinstance(v, list) and k in d:
-            d[k] += v
-        else:
-            d[k] = v
-    return d
+    def add_cli_options(self, options):
+        if not options:
+            return
+        if options.silent is not None:
+            self.silent = options.silent
+        if options.verbose is not None:
+            self.verbose = options.verbose
 
 
 def get_line_range():
@@ -210,7 +224,7 @@ def get_line_range():
     return [int(line_start or 0), int(line_end or 10000000)]
 
 
-def should_stop():
+def should_end():
     another = input("Would you like to add another line range (y/n)?\n>> ") or "n"
     return another.startswith("n")
 
@@ -224,19 +238,10 @@ def get_project_metadata():
     return username, project, filepath
 
 
-def display_configuration(config):
-    print("=================================")
-    print("Updated configuration:")
-    print("")
-    print((yaml.dump(config)))
-    print("=================================")
-    print("")
-
-
-def get_api_base_url(config):
-    base_url = config.get('github_api_base_url')
-    if base_url:
-        return base_url
+def get_api_base_url(username, config):
+    for user in config.users:
+        if user.name == username:
+            return user.base_url
     base_url = input("What is the base API url for your github site? (api.github.com)\n>> ")
     if base_url:
         return base_url
@@ -245,9 +250,11 @@ def get_api_base_url(config):
 
 def main(parser):
     try:
-        config = get_config(parser)
+        config = Configuration.from_file()
     except RuntimeError:
-        config = {}
+        config = Configuration(users=[])
+
+    config.add_cli_options(parser)
 
     while True:
         username, project, filepath = get_project_metadata()
@@ -256,22 +263,25 @@ def main(parser):
             line_ranges = []
             while True:
                 line_ranges.append(get_line_range())
-                if should_stop(): break
-        config = update(config, {
-            'github_api_base_url': get_api_base_url(config),
-            username: {
-                project: {
-                    filepath: line_ranges
-                }
-            }
-        })
-        display_configuration(config)
+                if should_end(): break
+
+        config.append_user(User(
+            name=username,
+            base_url=get_api_base_url(username, config),
+            token='',
+            repos=[Repo(name=project,
+                        regexes=[],
+                        paths=[Path(
+                            path=filepath,
+                            ranges=[Range(start, end) for start, end in line_ranges])])]))
+
         add_another_file = input("Would you like to add another (a), or quit (q)?\n(q) >> ") or "q"
         if add_another_file.startswith('q'):
             break
+    print(config.serialize())
     write = input("Write the config (y/n)?\n(n) >> ")
     if write.startswith('y'):
         with open(settings.WATCHER_CONFIG, 'w+') as config_fp:
-            config_fp.write(yaml.dump(config))
-    if 'github_api_secret_token' not in config:
-        print("You will need to add your `github_api_secret_token` to {}".format(settings.WATCHER_CONFIG))
+            config_fp.write(config.serialize())
+    print("You will need to add your `token` to {}".format(settings.WATCHER_CONFIG))
+    return config

--- a/github_watcher/github-watcher
+++ b/github_watcher/github-watcher
@@ -25,28 +25,8 @@ run|config - *run* Runs the daemon. Watches files and alerts when there is a pul
 def parse_cli():
     parser = argparse.ArgumentParser(description='')
     parser.add_argument('action', default='run', help=ACTION_HELP)
-    parser.add_argument('--verbose', dest='verbose', action='store_true', default=False)
-    parser.add_argument('--repo', dest='repo', default=None,
-                        help='Used with "github-watcher check" to specify the repository to check. Required for check.')
-    parser.add_argument('--user', dest='user', default=None,
-                        help='Used with "github-watcher check" to specify the user who owns the repostory to check. ' +
-                             'Required for check.')
-    parser.add_argument('--filepath', dest='filepath', default=None,
-                        help='Used with "github-watcher check" to specify the filepath to check. Required for check.')
-    parser.add_argument('--start-lineno', dest='start', default=0,
-                        help='Used with "github-watcher check" to specify the start of the line range to check. ' +
-                             'Optional.')
-    parser.add_argument('--end-lineno', dest='end', default=1000000,
-                        help='Used with "github-watcher check" to speficy the end of the line range to check. ' +
-                             'Optional.')
-    parser.add_argument('--github-url', dest='github_url', default=None,
-                        help='Supply a non-default github url where your enterprise installation can be found. It ' +
-                             'should probably end with /api/v3. Defaults to the api.github.com API')
-    parser.add_argument('--regex', dest='regex', default=None,
-                        help='Pass a regular expression. If a match if found in either a source or a destination ' +
-                             'file you will be alerted regardless of whether or not the file appears in your ' +
-                             'configuration')
-    parser.add_argument('--silent', dest='silent', default=False, help='Don\'t make audio alerts where supported.')
+    parser.add_argument('--verbose', dest='verbose', action='store_true', default=None)
+    parser.add_argument('--silent', dest='silent', default=None, help='Don\'t make audio alerts where supported.')
     return parser, parser.parse_args()
 
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ elif SYSTEM == 'Linux' and not os.environ.get('TRAVIS'):
 
 
 setup(name='github_watcher',
-        version='3.7',
+        version='4.0',
         description='Monitors files/directories on github and alerts you when someone submits a PR with changes',
         author='Andrew Kelleher',
         author_email='keats.kelleher@gmail.com',

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -8,9 +8,16 @@ class TestCheck(unittest.TestCase):
 
     def test_main(self):
         parser = mock.MagicMock()
-        with mock.patch('github_watcher.commands.check.get_config') as get_config:
-            with mock.patch('github_watcher.commands.check.find_changes') as find_changes:
-                get_config.return_value = 1
+        with mock.patch('github_watcher.commands.check.find_changes') as find_changes:
+            with mock.patch('github_watcher.commands.config.Configuration.from_file') as from_file:
+                args = mock.MagicMock()
+                conf = mock.MagicMock()
+
+                parser.parse_args.return_value = args
+                from_file.return_value = conf
+
                 check.main(parser)
-                get_config.assert_any_call(parser)
-                find_changes.assert_any_call(1)
+
+                from_file.assert_called_once()
+                conf.add_cli_options.assert_any_call(args)
+                find_changes.assert_any_call(conf)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,213 +9,72 @@ import github_watcher.commands.config as config
 
 class TestConfig(unittest.TestCase):
 
-    def test_nonempty_watch_path(self):
-        args = mock.MagicMock()
-        args.user = 'akellehe'
-        args.repo = 'github-watcher'
-        args.filepath = 'path/to/some/file.py'
-        self.assertTrue(config.nonempty_watch_path(args))
-
-        args = mock.MagicMock()
-        args.user = 'akellehe'
-        args.repo = None
-        args.filepath = None
-        with self.assertRaisesRegex(RuntimeError,
-            "If you pass any of --user, --repo, and --filepath you must pass all of them."):
-            config.nonempty_watch_path(args)
-
-        args = mock.MagicMock()
-        args.user = None
-        args.repo = None
-        args.filepath = None
-        self.assertFalse(config.nonempty_watch_path(args))
-
-    def test_get_cli_config(self,):
-        args = mock.MagicMock()
-        github_url = 'http://github.com'
-        args.github_url = github_url
-        args.user = 'akellehe'
-        args.repo = 'github-watcher'
-        args.filepath = '/'
-        args.start = 0
-        args.end = 100
-        args.regex = 'foobar'
-        args.silent = False
-        parser = mock.MagicMock()
-        parser.parse_args.return_value = args
-        observed_config = config.get_cli_config(parser)
-        self.assertEqual(observed_config, {
-            'github_api_base_url': github_url,
-            'akellehe': {
-                'github-watcher': {
-                    '/': [[0, 100]]
-                }
-            },
-            'watched_regexes': ['foobar']
-        })
-
     def test_get_file_config(self):
         tmpfile = tempfile.NamedTemporaryFile()
         expected = {
-            'github_api_base_url': 'https://github.com',
             'akellehe': {
-                'github-watcher': {
-                    '/': [[0, 100]]
+                'base_url': 'https://github.com',
+                'token': '',
+                'repos': {
+                    'github-watcher': {
+                        'paths': {'/': [[0, 100]]},
+                        'regexes': [],
+                    }
                 }
             }
         }
         tmpfile.write(bytes(yaml.dump(expected), 'utf8'))
         tmpfile.flush()
         with mock.patch('github_watcher.settings.WATCHER_CONFIG', tmpfile.name):
-            observed = config.get_file_config()
+            observed = config.Configuration.from_file().to_json()
             self.assertEqual(expected, observed)
 
     def test_get_file_config_with_regexes(self):
         tmpfile = tempfile.NamedTemporaryFile()
         expected = {
-            'github_api_base_url': 'https://github.com',
             'akellehe': {
-                'github-watcher': {
-                    '/': [[0, 100]]
-                }
-            },
-            'watched_regexes': ['foo', 'bar', 'pants']
+                'repos': {
+                    'github-watcher': {
+                        'paths': {
+                            '/': [[0, 100]]
+                        },
+                        'regexes': ['foo', 'bar'],
+                    },
+                },
+                'base_url': 'https://github.com',
+                'token': ''
+            }
         }
         tmpfile.write(bytes(yaml.dump(expected), 'utf8'))
         tmpfile.flush()
         with mock.patch('github_watcher.settings.WATCHER_CONFIG', tmpfile.name):
-            observed = config.get_file_config()
+            observed = config.Configuration.from_file(tmpfile.name).to_json()
             self.assertEqual(expected, observed)
 
-    def test_get_config_raises_runtime_error(self):
-        parser = mock.MagicMock()
-        with mock.patch('github_watcher.settings.WATCHER_CONFIG', ''):
-            with mock.patch('github_watcher.commands.config.get_cli_config',
-                            return_value={}):
-                with self.assertRaisesRegex(RuntimeError, 'No configuration found.'):
-                    config.get_config(parser)
+    def test_config_from_file_raises_runtime_error(self):
+        with self.assertRaisesRegex(RuntimeError, 'Config file not found <>'):
+            config.Configuration.from_file('')
 
-    @mock.patch('github_watcher.commands.config.get_cli_config')
-    def test_get_config_returns_cli_config_with_no_file_config(self, get_cli_config):
-        get_cli_config.return_value = {
-            'github_api_base_url': 'my url',
-            'github_api_secret_token': '*****',
-            'my': 'cli config'
-        }
-        parser = mock.MagicMock()
-        with mock.patch('github_watcher.settings.WATCHER_CONFIG', ''):
-            conf = config.get_config(parser)
-            self.assertEqual(conf, get_cli_config.return_value)
-
-    @mock.patch('github_watcher.commands.config.get_cli_config')
-    def test_get_config_returns_file_config_with_no_cli_config(self, get_cli_config):
-        get_cli_config.return_value = {}
-        parser = mock.MagicMock()
+    def test_basic_file_config(self):
         tmpfile = tempfile.NamedTemporaryFile()
-        expected = {
-            'github_api_base_url': 'https://github.com',
-            'github_api_secret_token': '*****',
-            'akelleh': {
-                'github-watcher-2': {
-                    'foobar/': [[10, 15]]
-                }
-            }
-        }
-        tmpfile.write(bytes(yaml.dump(expected), 'utf8'))
+        expected = {'akellehe': {
+            'repos': {
+                'github_watcher': {
+                    'paths': {
+                        'docs/': [],
+                        'github_watcher/settings.py': [[0, 1], [4, 5]]
+                    },
+                    'regexes': ['foo', 'bar']
+                },
+            },
+            'base_url': 'https://api.gitub.com',
+            'token': '*****',
+        }}
+        tmpfile.write(bytes(yaml.dump(expected, default_flow_style=False), 'utf8'))
         tmpfile.flush()
         with mock.patch('github_watcher.settings.WATCHER_CONFIG', tmpfile.name):
-            conf = config.get_config(parser)
-            self.assertEqual(expected, conf)
-
-    @mock.patch('github_watcher.commands.config.get_cli_config')
-    def test_get_config_overrides_file_config_with_cli_config(self, get_cli_config):
-        get_cli_config.return_value = {
-            'akelleh': {
-                'bazbiz': {
-                    'pants/': [[1, 2], [3, 4]]
-                }
-            }
-        }
-        parser = mock.MagicMock()
-        tmpfile = tempfile.NamedTemporaryFile()
-        fileconf = {
-            'github_api_base_url': 'https://github.com',  # should fall back to this one
-            'github_api_secret_token': '*****',
-            'akelleh': {
-                'github-watcher-2': {
-                    'foobar/': [[10, 15]]
-                }
-            }
-        }
-        tmpfile.write(bytes(yaml.dump(fileconf), 'utf8'))
-        tmpfile.flush()
-        with mock.patch('github_watcher.settings.WATCHER_CONFIG', tmpfile.name):
-            self.assertEqual(
-                config.get_config(parser),
-                {
-                    'github_api_base_url': 'https://github.com',
-                    'github_api_secret_token': '*****',
-                    'akelleh': {
-                        'bazbiz': {
-                            'pants/': [[1, 2], [3, 4]]
-                        }
-                    }
-                }
-            )
-
-    def test_update(self):
-        old = {
-            'github_api_base_url': 'http://github.old.com',
-            'github_api_secret_token': 'old token',
-            'old username': {
-                'old project name': {
-                    'old file name': [[0, 1], [2, 3]],
-                    'old file name 2': [[4, 5], [6, 7]]
-                }
-            },
-            'not replaced': {
-                'foo': {
-                    'bar': [[12, 23]]
-                }
-            }
-        }
-        overrides = {
-            'github_api_base_url': 'http://github.new.com',
-            'old username': {
-                'old project name': {
-                    'old file name': [[8, 9]],
-                    'new file name': [[10, 11]]
-                }
-            },
-            'new username': {
-                'new project': {
-                    'new file 2': [[1, 2]]
-                }
-            }
-        }
-        expected = {
-            'github_api_base_url': 'http://github.new.com',
-            'github_api_secret_token': 'old token',
-            'old username': {
-                'old project name': {
-                    'old file name': [[0, 1], [2, 3], [8, 9]],
-                    'old file name 2': [[4, 5], [6, 7]],
-                    'new file name': [[10, 11]]
-                }
-            },
-            'not replaced': {
-                'foo': {
-                    'bar': [[12, 23]]
-                }
-            },
-            'new username': {
-                'new project': {
-                    'new file 2': [[1, 2]]
-                }
-            }
-        }
-        observed = config.update(old, overrides)
-        self.assertEqual(expected, observed)
+            conf = config.Configuration.from_file(tmpfile.name)
+            self.assertEqual(expected, conf.to_json())
 
     @mock.patch('github_watcher.commands.config.input')
     def test_get_line_range(self, _input):
@@ -226,9 +85,9 @@ class TestConfig(unittest.TestCase):
         _input.assert_any_call("What is the end of the line range you would like to watch in that file?\n(infinity) >> ")
 
     @mock.patch('github_watcher.commands.config.input')
-    def test_should_stop(self, _input):
+    def test_should_end(self, _input):
         _input.return_value = 'y'
-        self.assertFalse(config.should_stop())
+        self.assertFalse(config.should_end())
         _input.assert_any_call("Would you like to add another line range (y/n)?\n>> ")
 
     @mock.patch('github_watcher.commands.config.input')
@@ -250,144 +109,140 @@ class TestConfig(unittest.TestCase):
         _input.assert_any_call("What is the file path you would like to watch (directories must end with /)?\n>> ")
         _input.assert_any_call("No absolute file paths. Try again.\n>> ")
 
-    @mock.patch('github_watcher.commands.config.should_stop')
-    @mock.patch('github_watcher.commands.config.display_configuration')
-    @mock.patch('github_watcher.commands.config.get_project_metadata')
+    @mock.patch('github_watcher.commands.config.should_end')
     @mock.patch('github_watcher.commands.config.input')
-    @mock.patch('github_watcher.commands.config.get_config')
-    def test_main(self, get_config, _input, get_project_metadata, display_configuration, should_stop):
-        get_project_metadata.return_value = ('username', 'project', 'filepath')
-        should_stop.return_value = True
-        get_config.return_value = {}
-
-        args = mock.MagicMock()
-        github_url = 'http://github.com'
-        args.github_url = github_url
-        args.user = 'akellehe'
-        args.repo = 'github-watcher'
-        args.filepath = '/'
-        args.start = 0
-        args.end = 100
-        parser = mock.MagicMock()
-        parser.parse_args.return_value = args
-
-        tmpfile = tempfile.NamedTemporaryFile()
-        tmpfile.write(bytes('', 'utf8'))
-        tmpfile.flush()
-        with mock.patch('github_watcher.settings.WATCHER_CONFIG', tmpfile.name):
-            with mock.patch('github_watcher.commands.config.input') as inp:
-                inp.return_value = ''
-                config.main(parser)
-
-        get_config.assert_any_call(parser)
-        get_project_metadata.assert_called()
-        display_configuration.assert_any_call({'github_api_base_url': 'https://api.github.com', 'username': {'project': {'filepath': [[0, 10000000]]}}})
-
-    @mock.patch('github_watcher.commands.config.should_stop')
-    @mock.patch('github_watcher.commands.config.display_configuration')
-    @mock.patch('github_watcher.commands.config.input')
-    @mock.patch('github_watcher.commands.config.get_config')
-    def test_main_with_write_config(self, get_config, _input, display_configuration, should_stop):
-        should_stop.return_value = True
-        get_config.return_value = {}
-
-        args = mock.MagicMock()
-        github_url = 'http://github.com'
-        args.github_url = github_url
-        args.user = 'akellehe'
-        args.repo = 'github-watcher'
-        args.filepath = '/'
-        args.start = 0
-        args.end = 100
-        parser = mock.MagicMock()
-        parser.parse_args.return_value = args
-
-        tmpfile = tempfile.NamedTemporaryFile()
-        tmpfile.write(bytes('', 'utf8'))
-        tmpfile.flush()
-        with mock.patch('github_watcher.settings.WATCHER_CONFIG', tmpfile.name):
-            with mock.patch('github_watcher.commands.config.input') as inp:
-                inp.side_effect = ['username', 'project', 'filepath', 0, 10, 'my base url', 'q', 'y']
-                config.main(parser)
-
-        get_config.assert_any_call(parser)
-        display_configuration.assert_any_call({'github_api_base_url': 'my base url', 'username': {'project': {'filepath': [[0, 10]]}}})
-
-    @mock.patch('github_watcher.commands.config.should_stop')
-    @mock.patch('github_watcher.commands.config.display_configuration')
-    @mock.patch('github_watcher.commands.config.get_project_metadata')
-    @mock.patch('github_watcher.commands.config.input')
-    @mock.patch('github_watcher.commands.config.get_config')
-    def test_main_with_runtime_error(self, get_config, _input, get_project_metadata, display_configuration, should_stop):
-        get_project_metadata.return_value = ('username', 'project', 'filepath')
-        should_stop.return_value = True
-        get_config.side_effect = RuntimeError
-
-        args = mock.MagicMock()
-        github_url = 'http://github.com'
-        args.github_url = github_url
-        args.user = 'akellehe'
-        args.repo = 'github-watcher'
-        args.filepath = '/'
-        args.start = 0
-        args.end = 100
-        parser = mock.MagicMock()
-        parser.parse_args.return_value = args
-
-        tmpfile = tempfile.NamedTemporaryFile()
-        tmpfile.write(bytes('', 'utf8'))
-        tmpfile.flush()
-        with mock.patch('github_watcher.settings.WATCHER_CONFIG', tmpfile.name):
-            with mock.patch('github_watcher.commands.config.input') as inp:
-                inp.return_value = ''
-                config.main(parser)
-                get_config.assert_any_call(parser)
-                get_project_metadata.assert_called()
-                display_configuration.assert_any_call({'github_api_base_url': 'https://api.github.com', 'username': {'project': {'filepath': [[0, 10000000]]}}})
-
     @mock.patch('github_watcher.commands.config.print')
-    def test_display_configuration(self, _print):
-        config.display_configuration({'my': 'configuration'})
-        _print.assert_any_call("Updated configuration:")
+    def test_main(self, _print, _input, should_end):
+        _input.side_effect = ['username', 'project', 'filepath', 0, 10, 'my base url', 'q', 'y']
+        should_end.return_value = True
+        args = mock.MagicMock()
+        args.silent = True
+        args.verbose = False
+        parser = mock.MagicMock()
+        parser.parse_args.return_value = args
+        tmpfile = tempfile.NamedTemporaryFile()
+        tmpfile.write(bytes('', 'utf8'))
+        tmpfile.flush()
+        with mock.patch('github_watcher.settings.WATCHER_CONFIG', tmpfile.name):
+            c = config.main(parser)
+        _print.assert_any_call("""username:
+  base_url: my base url
+  repos:
+    project:
+      paths:
+        filepath:
+        - - 0
+          - 10
+      regexes: []
+  token: ''
+""")
+
+    @mock.patch('github_watcher.commands.config.should_end')
+    @mock.patch('github_watcher.commands.config.input')
+    def test_main_with_write_new_user_config(self, _input, should_end):
+        should_end.return_value = True
+        expected = {'akellehe': {
+            'base_url': 'https://api.gitub.com',
+            'token': '*****',
+            'repos': {
+                'github_watcher': {
+                    'paths': {
+                        'docs/': [],
+                        'github_watcher/settings.py': [[0, 1], [4, 5]]
+                    },
+                    'regexes': ['foo', 'bar']
+                },
+            }
+        }}
+        tmpfile = tempfile.NamedTemporaryFile()
+        tmpfile.write(bytes(yaml.dump(expected), 'utf8'))
+        tmpfile.flush()
+        with mock.patch('github_watcher.settings.WATCHER_CONFIG', tmpfile.name):
+            with mock.patch('github_watcher.commands.config.input') as inp:
+                with mock.patch('github_watcher.commands.config.print') as _print:
+                    inp.side_effect = ['username', 'project', 'filepath', 0, 10, 'my base url', 'q', 'y']
+                    config.main(None)
+        expected = """akellehe:
+  base_url: https://api.gitub.com
+  repos:
+    github_watcher:
+      paths:
+        docs/: []
+        github_watcher/settings.py:
+        - - 0
+          - 1
+        - - 4
+          - 5
+      regexes:
+      - foo
+      - bar
+  token: '*****'
+username:
+  base_url: my base url
+  repos:
+    project:
+      paths:
+        filepath:
+        - - 0
+          - 10
+      regexes: []
+  token: ''
+"""
+        with open(tmpfile.name, 'rb') as fp:
+            self.assertEqual(fp.read().decode('utf8'), expected)
+
+    @mock.patch('github_watcher.commands.config.should_end')
+    @mock.patch('github_watcher.commands.config.input')
+    def test_main_with_runtime_error(self, _input, should_end):
+        _input.side_effect = ['username', 'project', 'filepath', 0, 10, 'my base url', 'q', 'y']
+        should_end.return_value = True
+
+        tmpfile = tempfile.NamedTemporaryFile()
+        tmpfile.write(bytes('', 'utf8'))
+        tmpfile.flush()
+        with mock.patch('github_watcher.settings.WATCHER_CONFIG', tmpfile.name):
+            with mock.patch('github_watcher.commands.config.input') as inp:
+                inp.return_value = ''
+                config.main(None)
 
     def test_get_api_base_url(self):
-        conf = {'github_api_base_url': 'my base url'}
-        base_url = config.get_api_base_url(conf)
-        self.assertEqual(base_url, 'my base url')
+        conf = config.Configuration(users=[config.User(name='akellehe', repos=[], token='', base_url='foobar')])
+        base_url = config.get_api_base_url('akellehe', conf)
+        self.assertEqual(base_url, 'foobar')
 
         with mock.patch('github_watcher.commands.config.input') as _input:
-            conf = {'github_api_base_url': None}
+            conf = config.Configuration(users=[])
             _input.return_value = 'second base url'
-            base_url = config.get_api_base_url(conf)
+            base_url = config.get_api_base_url('akellehe', conf)
             self.assertEqual(base_url, 'second base url')
 
         with mock.patch('github_watcher.commands.config.input') as _input:
-            conf = {'github_api_base_url': None}
+            conf = config.Configuration(users=[])
             _input.return_value = None
-            base_url = config.get_api_base_url(conf)
+            base_url = config.get_api_base_url('akellehe', conf)
 
         self.assertEqual(base_url, 'https://api.github.com')
 
-    def test_configuration_model(self):
+    def test_configuration_model_from_yml(self):
         conf = {'akellehe': {
-            'github_watcher': {
-                'paths': {
-                    'docs/': None,
-                    'github_watcher/settings.py': [[0, 1], [4, 5]]
+            'base_url': 'https://api.gitub.com',
+            'token': '*****',
+            'repos': {
+                'github_watcher': {
+                    'paths': {
+                        'docs/': None,
+                        'github_watcher/settings.py': [[0, 1], [4, 5]]
+                    },
+                    'regexes': ['foo', 'bar']
                 },
-                'base_url': 'https://api.gitub.com',
-                'token': '*****',
-                'regexes': ['foo', 'bar']
-            },
-            'github_watcher_2': {
-                'paths': {'docs/': None,
-                          'github_watcher/settings.py': [[0, 1], [4, 5]]},
-                'base_url': 'https://api.gitub.com',
-                'token': '*****',
-                'regexes': ['foo', 'bar']
+                'github_watcher_2': {
+                    'paths': {'docs/': None,
+                              'github_watcher/settings.py': [[0, 1], [4, 5]]},
+                    'regexes': ['foo', 'bar']
+                }
             }
         }}
-        target = config.Configuration.from_yml(conf)
+        target = config.Configuration.from_json(conf)
 
         self.assertEqual(len(target.users), 1)
         self.assertEqual(target.users[0].name, 'akellehe')
@@ -397,9 +252,30 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(target.users[0].repos[1].paths[0].ranges, [])
         self.assertEqual(target.users[0].repos[1].paths[1].path, 'github_watcher/settings.py')
         self.assertEqual(target.users[0].repos[1].paths[1].ranges[0].start, 0)
-        self.assertEqual(target.users[0].repos[1].paths[1].ranges[0].stop, 1)
+        self.assertEqual(target.users[0].repos[1].paths[1].ranges[0].end, 1)
         self.assertEqual(target.users[0].repos[1].paths[1].ranges[1].start, 4)
-        self.assertEqual(target.users[0].repos[1].paths[1].ranges[1].stop, 5)
+        self.assertEqual(target.users[0].repos[1].paths[1].ranges[1].end, 5)
+
+    def test_configuration_to_from_json(self):
+        conf = {'akellehe': {
+            'repos': {
+                'github_watcher': {
+                    'paths': {
+                        'docs/': [],
+                        'github_watcher/settings.py': [[0, 1], [4, 5]]
+                    },
+                    'regexes': ['foo', 'bar']
+                },
+                'github_watcher_2': {
+                    'paths': {'docs/': [],
+                              'github_watcher/settings.py': [[0, 1], [4, 5]]},
+                    'regexes': ['foo', 'bar']
+                }
+            },
+            'base_url': 'https://api.gitub.com',
+            'token': '*****',
+        }}
+        self.assertEqual(config.Configuration.from_json(conf).to_json(), conf)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Creating a grammar allows us to make complex nexted functionality within our configs. Now we can parse those configs into objects and convert back and forth to yaml and json, for example.

This release includes

  - `base_url` and `token` are namespaced at the `Repo` level.
  - `repos` separates repository configurations from the other "root level" configurations
  - `paths` and `regexes` are namespaced at the `Repo` level.
  - Better documentation around configuration.