### PR TITLE
Adds functionality to "clean" a repository

### DIFF
--- a/github_watcher/commands/clean.py
+++ b/github_watcher/commands/clean.py
@@ -1,0 +1,153 @@
+"""
+This module implements methods to sanitize your code base. It automates some best practices such as
+
+- Enforce users to fork rather than branching off the organization code base
+- Close/delete branches and pull requests that match particular criteria
+- Comment on branches that match certain criteria
+
+The supported actions vary based on whether you're operating on a pull request or a branch.
+
++----------------+----------------+
+| Branches       | Pull Requests  |
++================+================+
+| Delete         | Close          |
++----------------+----------------+
+|                | Comment        |
++----------------+----------------+
+
+Available CLI arguments include
+
++----------------+----------------+---------+------------------------------------------------------------------+
+| CLI Argument   | Argument       | Default | Description                                                      |
++================+================+=========+==================================================================+
+| --older-than   | YYYY-MM-DD     | None    | Branches and pull requests last updated before this date will be |
+|                |                |         | matched.                                                         |
++----------------+----------------+---------+------------------------------------------------------------------+
+| --dry-run      | (none)         | False   | Will print out what would happen, but doesn't apply any changes. |
++----------------+----------------+---------+------------------------------------------------------------------+
+| --close        | (none)         | False   | If passed; will close matched pull requests unless --dry-run is  |
+|                |                |         | also passed.                                                     |
++----------------+----------------+---------+------------------------------------------------------------------+
+| --delete       | (none)         | False   | If passed; will delete matched branches.                         |
++----------------+----------------+---------+------------------------------------------------------------------+
+| --comment      | str            | ""      | If passed; will comment on matched pull requests with the        |
+|                |                |         | argument passed.                                                 |
++----------------+----------------+---------+------------------------------------------------------------------+
+
+"""
+
+import logging
+import datetime
+import json
+
+import github_watcher.services.git as git
+import github_watcher.commands.config as config
+
+
+def _datetime_strptime(string, _format):
+    """
+    Convenience function because datetime attributes are built-in and not patch-able
+    """
+    return datetime.datetime.strptime(string, _format)
+
+
+def clean_branch(branch, opts):
+    """
+    Cleans the branch, `branch` based on the options passed by the user.
+
+    :param github.Branch.Branch branch: The branch to clean.
+    :param opts: User defined options (on the CLI) specifying how the branches should be cleaned.
+    """
+    logging.info('opts.comment %s, opts.delete %s', opts.comment, opts.delete)
+    if opts.comment:
+        logging.info('commenting. %s', opts.comment)
+        git.comment(branch, message=opts.comment, dry_run=opts.dry_run)
+    if opts.delete:
+        logging.info('deleting')
+        git.delete(branch, dry_run=opts.dry_run)
+
+
+def clean_pull_request(pull_request, opts):
+    """
+    Cleans the pull request, `pull_request`, based on the options passed by the user.
+    :param github.PullRequest.PullRequest pull_request: The pull request to clean.
+    :param opts: The user defined options about how to clean this PR.
+    """
+    logging.info('opts.close %s, opts.comments %s', opts.close, opts.comment)
+    if opts.close:
+        logging.info('closing.')
+        git.close(pull_request, dry_run=opts.dry_run)
+    if opts.comment:
+        logging.info('commenting %s', opts.comment)
+        git.comment(pull_request, message=opts.comment, dry_run=opts.dry_run)
+
+
+def too_old(entity, cutoff: str=None) -> bool:
+    """
+    Given a `cutoff`, determines whether the `entity` is too old. If so, it's triggered as a match.
+
+    :param entity: A pull request or branch to decide whether or not it's too old.
+    :type entity: github.PullRequest.PullRequest|github.Branch.Branch
+    :param str cutoff: The YYYY-MM-DD formatted date at which to cut off entities.
+    :return bool: True if the entity is too old.
+    """
+    min_birthday = _datetime_strptime(cutoff, "%Y-%m-%d")
+    if git.get_last_updated(entity) < min_birthday:
+        return True
+    return False
+
+
+def should_clean_pull_request(pull_request, opts):
+    """
+    Determines whether or not a pull request should be cleaned based on the user-defined criteria.
+
+    :param github.PullRequest.PullRequest pull_request:
+    :param opts: User defined options.
+    :return: bool. True if the pull request should be cleaned.
+    """
+    if too_old(pull_request, opts.older_than):
+        return True
+    return False
+
+
+def should_clean_branch(branch, opts):
+    """
+    Determines whether or not a branch should be cleaned based on the user-defined criteria.
+
+    :param github.Branch.Branch branch:
+    :param opts: User defined options.
+    :return: bool. True if the pull request should be cleaned.
+    """
+    if too_old(branch, opts.older_than):
+        return True
+    return False
+
+
+def main(parser):
+    """
+    Executes checks one time.
+    """
+    logging.info("Running clean...")
+    conf = config.Configuration.from_file()
+    opts = parser.parse_args()
+    logging.info("Got configuration %s", json.dumps(conf.to_json()))
+    for user in conf.users:
+        logging.info("Getting repos for user %s", user.name)
+        for repo in user.repos:
+            logging.info("Checking repo %s, getting branches...", repo.name)
+            branches = git.get_branches(user, repo)
+            for branch in branches:
+                logging.info("Checking branch %s", branch.name)
+                if should_clean_branch(branch, opts):
+                    logging.info("cleaning!")
+                    clean_branch(branch, opts)
+
+            logging.info("Getting open pull requests...")
+            pull_requests = git.open_pull_requests(
+                user.base_url, user.token, user.name, repo.name)
+            for pull_request in pull_requests:
+                logging.info("Checking pull request %s", pull_request.title)
+                if should_clean_pull_request(pull_request, opts):
+                    logging.info("Cleaning...")
+                    clean_pull_request(pull_request, opts)
+

--- a/github_watcher/commands/config.py
+++ b/github_watcher/commands/config.py
@@ -230,6 +230,7 @@ class Configuration:
 
     @classmethod
     def from_json(cls, yml):
+        print('yml', yml)
         if not yml:
             raise RuntimeError("No configuration found.")
         return Configuration(

--- a/github_watcher/commands/run.py
+++ b/github_watcher/commands/run.py
@@ -9,7 +9,7 @@ against those configurations.
 It also manages alerting on those files across Linux and Darwin systems.
 
 """
-from typing import Dict, Tuple
+from typing import Tuple
 import re
 import os
 import logging

--- a/github_watcher/github-watcher
+++ b/github_watcher/github-watcher
@@ -3,7 +3,6 @@ import sys
 import time
 import logging
 import argparse
-import os.path
 
 import github_watcher
 import github_watcher.settings
@@ -11,6 +10,7 @@ import github_watcher.commands
 import github_watcher.commands.run
 import github_watcher.commands.check
 import github_watcher.commands.config
+import github_watcher.commands.clean
 
 
 THROTTLE_THRESHOLD = 600  # seconds
@@ -27,6 +27,20 @@ def parse_cli():
     parser.add_argument('action', default='run', help=ACTION_HELP)
     parser.add_argument('--verbose', dest='verbose', action='store_true', default=None)
     parser.add_argument('--silent', dest='silent', default=None, help='Don\'t make audio alerts where supported.')
+
+    # Sanitization methods.
+    parser.add_argument('--dry-run', dest='dry_run', action='store_true', default=True,
+                        help='Prints what it would do, instead of modifying stuff on github.')
+    parser.add_argument('--older-than', dest='older_than', default=None, help='Pass a date in YYYY-MM-DD format. All ' +
+                        'pull requests built on branches last updated earlier than this date will be closed. The ' +
+                        'associated branches will be deleted.')
+    parser.add_argument('--comment', dest='comment', default=None,
+                        help='Comment on pull requests matching the criteria defined. Pass the message here.')
+    parser.add_argument('--close', dest='close', default=False, action='store_true',
+                        help='Close pull requests matching the criteria defined.')
+    parser.add_argument('--delete', dest='delete', default=False, action='store_true',
+                        help='Delete pull requests and branches matching the criteria defined.')
+
     return parser, parser.parse_args()
 
 
@@ -60,6 +74,9 @@ def main():
         github_watcher.commands.config.main(parser)
     elif args.action == 'check':
         github_watcher.commands.check.main(parser)
+    elif args.action == 'clean':
+        logging.info('Cleaning...')
+        github_watcher.commands.clean.main(parser)
     else:
         parser.print_help()
         raise SystemExit

--- a/github_watcher/services/git.py
+++ b/github_watcher/services/git.py
@@ -1,10 +1,44 @@
 import logging
+import datetime
 
+import github
 from github import Github
 import requests
 
 
 class Noop(Exception): pass
+
+
+def close(entity, dry_run=True):
+    print('would close', type(entity), get_last_updated(entity))
+
+
+def comment(entity, message=None, dry_run=True):
+    if not dry_run:
+        if isinstance(github.PullRequest.PullRequest):
+            logging.info("Create issue comment %s on %s", message, entity)
+            entity.create_issue_comment(message)
+        elif isinstance(github.Branch.Branch):
+            logging.info("Create commit comment %s on %s", message, entity)
+            entity.commit.create_comment(message)
+
+
+def delete(entity, dry_run=True):
+    print('would delete', type(entity), get_last_updated(entity))
+
+
+def get_branches(user, repo):
+    gh = Github(user.token, base_url=user.base_url)
+    repo = gh.get_repo(user.name + '/' + repo.name)
+    return repo.get_branches()
+
+
+def get_last_updated(entity=None):
+    if isinstance(entity, github.PullRequest.PullRequest):
+        return pr.updated_at
+    elif isinstance(entity, github.Branch.Branch):
+        last_modified_str = entity.commit.stats.last_modified
+        return datetime.datetime.strptime(last_modified_str, "%a, %d %b %Y %H:%M:%S %Z")
 
 
 def open_pull_requests(base_url, access_token, user, repo):

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -1,0 +1,304 @@
+import unittest
+import datetime
+import unittest.mock as mock
+
+import github_watcher.commands.clean as clean
+import github_watcher.commands.config as config
+
+
+
+class TestClean(unittest.TestCase):
+
+    def test_clean_branch_with_no_options(self):
+        branch = mock.MagicMock()
+        options = mock.MagicMock()
+        options.comment = None
+        options.delete = None
+        with mock.patch('github_watcher.commands.clean.git.comment') as comment:
+            with mock.patch('github_watcher.commands.clean.git.delete') as delete:
+                clean.clean_branch(branch, options)
+                comment.assert_not_called()
+                delete.assert_not_called()
+
+    def test_clean_branch_with_delete_only(self):
+        branch = mock.MagicMock()
+        options = mock.MagicMock()
+        options.comment = None
+        options.delete = True
+        options.dry_run = True
+        with mock.patch('github_watcher.commands.clean.git.comment') as comment:
+            with mock.patch('github_watcher.commands.clean.git.delete') as delete:
+                clean.clean_branch(branch, options)
+                comment.assert_not_called()
+                delete.assert_any_call(branch, dry_run=True)
+
+    def test_clean_branch_with_comment_only(self):
+        branch = mock.MagicMock()
+        options = mock.MagicMock()
+        options.comment = 'foo bar'
+        options.delete = False
+        options.dry_run = True
+        with mock.patch('github_watcher.commands.clean.git.comment') as comment:
+            with mock.patch('github_watcher.commands.clean.git.delete') as delete:
+                clean.clean_branch(branch, options)
+                comment.assert_any_call(branch, message='foo bar', dry_run=True)
+                delete.assert_not_called()
+
+    def test_clean_branch_with_both(self):
+        branch = mock.MagicMock()
+        options = mock.MagicMock()
+        options.comment = 'foo bar'
+        options.delete = True
+        options.dry_run = True
+        with mock.patch('github_watcher.commands.clean.git.comment') as comment:
+            with mock.patch('github_watcher.commands.clean.git.delete') as delete:
+                clean.clean_branch(branch, options)
+                comment.assert_any_call(branch, message='foo bar', dry_run=True)
+                delete.assert_any_call(branch, dry_run=True)
+
+    def test_clean_pull_request_with_no_options(self):
+        pull_request = mock.MagicMock()
+        options = mock.MagicMock()
+        options.comment = None
+        options.close = None
+        options.delete = None
+        options.dry_run = True
+        with mock.patch('github_watcher.commands.clean.git.comment') as comment:
+            with mock.patch('github_watcher.commands.clean.git.close') as close:
+                clean.clean_pull_request(pull_request, options)
+                comment.assert_not_called()
+                close.assert_not_called()
+
+    def test_clean_pull_request_with_close_only(self):
+        pull_request = mock.MagicMock()
+        options = mock.MagicMock()
+        options.comment = None
+        options.close = True
+        options.delete = None
+        options.dry_run = True
+        with mock.patch('github_watcher.commands.clean.git.comment') as comment:
+            with mock.patch('github_watcher.commands.clean.git.close') as close:
+                clean.clean_pull_request(pull_request, options)
+                comment.assert_not_called()
+                close.assert_any_call(pull_request, dry_run=True)
+
+    def test_clean_pull_request_with_comment_only(self):
+        pull_request = mock.MagicMock()
+        options = mock.MagicMock()
+        options.comment = 'foo bar'
+        options.close = None
+        options.delete = None
+        options.dry_run = True
+        with mock.patch('github_watcher.commands.clean.git.comment') as comment:
+            with mock.patch('github_watcher.commands.clean.git.close') as close:
+                clean.clean_pull_request(pull_request, options)
+                comment.assert_any_call(pull_request, message='foo bar', dry_run=True)
+                close.assert_not_called()
+
+    def test_clean_pull_request_with_both(self):
+        pull_request = mock.MagicMock()
+        options = mock.MagicMock()
+        options.comment = 'foo bar'
+        options.close = True
+        options.dry_run = True
+        with mock.patch('github_watcher.commands.clean.git.comment') as comment:
+            with mock.patch('github_watcher.commands.clean.git.close') as close:
+                clean.clean_pull_request(pull_request, options)
+                comment.assert_any_call(pull_request, message='foo bar', dry_run=True)
+                close.assert_any_call(pull_request, dry_run=True)
+
+    def test_clean_pull_request_does_not_delete(self):
+        pull_request = mock.MagicMock()
+        options = mock.MagicMock()
+        options.comment = None
+        options.close = None
+        options.delete = True
+        options.dry_run = True
+        with mock.patch('github_watcher.commands.clean.git.comment') as comment:
+            with mock.patch('github_watcher.commands.clean.git.close') as close:
+                with mock.patch('github_watcher.commands.clean.git.delete') as delete:
+                    clean.clean_pull_request(pull_request, options)
+                    comment.assert_not_called()
+                    close.assert_not_called()
+                    delete.assert_not_called()
+
+    @mock.patch('github_watcher.services.git.get_last_updated')
+    def test_too_old(self, get_last_updated):
+        get_last_updated.return_value = datetime.datetime.now()
+        entity = mock.MagicMock()
+        cutoff = '1970-12-01'
+        self.assertFalse(clean.too_old(entity, cutoff))
+
+        get_last_updated.return_value = datetime.datetime.now()
+        entity = mock.MagicMock()
+        cutoff = '3000-12-01'
+        self.assertTrue(clean.too_old(entity, cutoff))
+
+    @mock.patch('github_watcher.commands.clean.too_old')
+    def test_should_clean_pull_request(self, too_old):
+        too_old.return_value = True
+        pull_request = mock.MagicMock()
+        opts = mock.MagicMock()
+        self.assertTrue(clean.should_clean_pull_request(pull_request, opts))
+
+        too_old.return_value = False
+        pull_request = mock.MagicMock()
+        opts = mock.MagicMock()
+        self.assertFalse(clean.should_clean_pull_request(pull_request, opts))
+
+    @mock.patch('github_watcher.commands.clean.too_old')
+    def test_should_clean_branch(self, too_old):
+        too_old.return_value = True
+        branch = mock.MagicMock()
+        opts = mock.MagicMock()
+        self.assertTrue(clean.should_clean_branch(branch, opts))
+
+        too_old.return_value = False
+        branch = mock.MagicMock()
+        opts = mock.MagicMock()
+        self.assertFalse(clean.should_clean_branch(branch, opts))
+
+    @mock.patch('github_watcher.commands.clean.clean_pull_request')
+    @mock.patch('github_watcher.services.git.open_pull_requests')
+    @mock.patch('github_watcher.commands.clean.clean_branch')
+    @mock.patch('github_watcher.services.git.get_branches')
+    @mock.patch('github_watcher.commands.clean.should_clean_branch')
+    def test_main_with_only_branch_to_clean(self, should_clean_branch, get_branches, clean_branch, open_prs, clean_pr):
+        conf = config.Configuration.from_json({
+                'akellehe': {
+                    'repos': {
+                        'github_watcher': {
+                            'paths': {
+                                'A/PATH/TO/A/FILE.PY': [[0, 100]]
+                            },
+                            'regexes': ['foo', 'bar'],
+                        }
+                    },
+                    'token': '*****',
+                    'base_url': 'https://api.github.com'
+                    },
+                })
+        branch = mock.MagicMock()
+        open_prs.return_value = []
+        should_clean_branch.return_value = True
+        get_branches.return_value = [branch]
+        now = datetime.datetime.now()
+        opts = mock.MagicMock()
+        opts.older_than = now.strftime('%Y-%m-%d')
+        parser = mock.MagicMock()
+        parser.parse_args.return_value = opts
+        with mock.patch('github_watcher.commands.clean.config.Configuration.from_file') as ff:
+            ff.return_value = conf
+            clean.main(parser)
+        clean_branch.assert_called()
+        clean_pr.assert_not_called()
+
+    @mock.patch('github_watcher.commands.clean.clean_pull_request')
+    @mock.patch('github_watcher.services.git.open_pull_requests')
+    @mock.patch('github_watcher.commands.clean.clean_branch')
+    @mock.patch('github_watcher.services.git.get_branches')
+    @mock.patch('github_watcher.commands.clean.should_clean_branch')
+    def test_main_with_one_branch_to_clean_one_branch_not(self, should_clean_branch, get_branches, clean_branch, open_prs, clean_pr):
+        conf = config.Configuration.from_json({
+            'akellehe': {
+                'repos': {
+                    'github_watcher': {
+                        'paths': {
+                            'A/PATH/TO/A/FILE.PY': [[0, 100]]
+                        },
+                        'regexes': ['foo', 'bar'],
+                    }
+                },
+                'token': '*****',
+                'base_url': 'https://api.github.com'
+            },
+        })
+        branch_to_clean = mock.MagicMock()
+        branch_not_to_clean = mock.MagicMock()
+        open_prs.return_value = []
+        should_clean_branch.side_effect = [True, False]
+        get_branches.return_value = [branch_to_clean, branch_not_to_clean]
+        now = datetime.datetime.now()
+        opts = mock.MagicMock()
+        opts.older_than = now.strftime('%Y-%m-%d')
+        parser = mock.MagicMock()
+        parser.parse_args.return_value = opts
+        with mock.patch('github_watcher.commands.clean.config.Configuration.from_file') as ff:
+            ff.return_value = conf
+            clean.main(parser)
+        clean_branch.assert_called_once_with(branch_to_clean, opts)
+        clean_pr.assert_not_called()
+
+    @mock.patch('github_watcher.commands.clean.should_clean_pull_request')
+    @mock.patch('github_watcher.commands.clean.clean_pull_request')
+    @mock.patch('github_watcher.services.git.open_pull_requests')
+    @mock.patch('github_watcher.commands.clean.clean_branch')
+    @mock.patch('github_watcher.services.git.get_branches')
+    @mock.patch('github_watcher.commands.clean.should_clean_branch')
+    def test_main_with_only_pull_request_to_clean(self, should_clean_branch, get_branches, clean_branch, open_prs, clean_pr, should_clean_pull_request):
+        conf = config.Configuration.from_json({
+            'akellehe': {
+                'repos': {
+                    'github_watcher': {
+                        'paths': {
+                            'A/PATH/TO/A/FILE.PY': [[0, 100]]
+                        },
+                        'regexes': ['foo', 'bar'],
+                    }
+                },
+                'token': '*****',
+                'base_url': 'https://api.github.com'
+            },
+        })
+        pr_to_clean = mock.MagicMock()
+        open_prs.return_value = [pr_to_clean]
+        get_branches.return_value = []
+        should_clean_pull_request.return_value = True
+        open_prs.return_value = [pr_to_clean]
+        now = datetime.datetime.now()
+        opts = mock.MagicMock()
+        opts.older_than = now.strftime('%Y-%m-%d')
+        parser = mock.MagicMock()
+        parser.parse_args.return_value = opts
+        with mock.patch('github_watcher.commands.clean.config.Configuration.from_file') as ff:
+            ff.return_value = conf
+            clean.main(parser)
+        clean_branch.assert_not_called()
+        clean_pr.assert_called_once_with(pr_to_clean, opts)
+
+    @mock.patch('github_watcher.commands.clean.should_clean_pull_request')
+    @mock.patch('github_watcher.commands.clean.clean_pull_request')
+    @mock.patch('github_watcher.services.git.open_pull_requests')
+    @mock.patch('github_watcher.commands.clean.clean_branch')
+    @mock.patch('github_watcher.services.git.get_branches')
+    @mock.patch('github_watcher.commands.clean.should_clean_branch')
+    def test_main_with_one_pr_to_clean_one_pr_not(self, should_clean_branch, get_branches, clean_branch, open_prs, clean_pr, should_clean_pull_request):
+        conf = config.Configuration.from_json({
+            'akellehe': {
+                'repos': {
+                    'github_watcher': {
+                        'paths': {
+                            'A/PATH/TO/A/FILE.PY': [[0, 100]]
+                        },
+                        'regexes': ['foo', 'bar'],
+                    }
+                },
+                'token': '*****',
+                'base_url': 'https://api.github.com'
+            },
+        })
+        pr_to_clean = mock.MagicMock()
+        pr_not_to_clean = mock.MagicMock()
+        open_prs.return_value = [pr_to_clean, pr_not_to_clean]
+        get_branches.return_value = []
+        should_clean_pull_request.side_effect = [True, False]
+        now = datetime.datetime.now()
+        opts = mock.MagicMock()
+        opts.older_than = now.strftime('%Y-%m-%d')
+        parser = mock.MagicMock()
+        parser.parse_args.return_value = opts
+        with mock.patch('github_watcher.commands.clean.config.Configuration.from_file') as ff:
+            ff.return_value = conf
+            clean.main(parser)
+        clean_branch.assert_not_called()
+        clean_pr.assert_called_once_with(pr_to_clean, opts)


### PR DESCRIPTION
This feature provides the basic functionality for a user to apply some action to pull requests and branches matching the defined criteria. At the moment the actions include

  - comment
  - delete
  - close

Comments work for both, delete works for branches, close works for PRs. See documentation for more information.